### PR TITLE
feat: add obs-start command

### DIFF
--- a/cmd/darsrec/main.go
+++ b/cmd/darsrec/main.go
@@ -36,7 +36,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	client, err := rec.New(password)
+	client, err := rec.New("", password)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/darsrec/main.go
+++ b/cmd/darsrec/main.go
@@ -30,13 +30,22 @@ func (ac *AsyncConf) Confs() []*rec.RecordConfig {
 
 func main() {
 
-	password := os.Getenv("OBS_WEBSOCKET_PASSWORD")
-	if password == "" {
-		fmt.Println("OBS_WEBSOCKET_PASSWORD is unset, cannot proceed")
-		os.Exit(1)
+	var host, password string
+	{
+		host = os.Getenv("OBS_WEBSOCKET_HOST")
+		if host == "" {
+			host = "localhost:4455"
+			fmt.Printf("OBS_WEBSOCKET_HOST not set, using default %s\f", host)
+		}
+
+		password = os.Getenv("OBS_WEBSOCKET_PASSWORD")
+		if password == "" {
+			fmt.Println("OBS_WEBSOCKET_PASSWORD is unset, cannot proceed")
+			os.Exit(1)
+		}
 	}
 
-	client, err := rec.New("", password)
+	client, err := rec.New(host, password)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/discord_bot/main.go
+++ b/cmd/discord_bot/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 
 	"github.com/ccil-kbw/robot/discord"
 )
@@ -17,10 +16,5 @@ var (
 func init() { flag.Parse() }
 
 func main() {
-	msgs := make(chan string)
-	go discord.Run(GuildID, BotToken, RemoveCommands, msgs)
-
-	for msg := range msgs {
-		fmt.Println(msg)
-	}
+	go discord.Run(GuildID, BotToken, RemoveCommands, nil)
 }

--- a/cmd/discord_bot/main.go
+++ b/cmd/discord_bot/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/ccil-kbw/robot/discord"
 )
@@ -16,5 +17,10 @@ var (
 func init() { flag.Parse() }
 
 func main() {
-	discord.Run(GuildID, BotToken, RemoveCommands)
+	msgs := make(chan string)
+	go discord.Run(GuildID, BotToken, RemoveCommands, msgs)
+
+	for msg := range msgs {
+		fmt.Println(msg)
+	}
 }

--- a/discord/discord.go
+++ b/discord/discord.go
@@ -4,9 +4,11 @@
 package discord
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/ccil-kbw/robot/mappers"
 
@@ -21,34 +23,35 @@ var (
 			Description: "Get Today's Iqama",
 		},
 		{
-			Name:        "test",
-			Description: "Some test command",
+			Name:        "obs-start",
+			Description: "Start Recording on the Main Camera (e.g unscheduled speech @ccil-kbw)",
 		},
 	}
 
-	commandHandlers = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
-		"iqama": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	commandHandlers = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate, msgs chan string){
+		"iqama": func(s *discordgo.Session, i *discordgo.InteractionCreate, msgs chan string) {
 			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: mappers.IqamaTimesToDiscordInteractionResponseData(iqamav1.Get()),
 			})
 		},
-		"test": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+		"obs-start": func(s *discordgo.Session, i *discordgo.InteractionCreate, msgs chan string) {
 			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
 					Embeds: []*discordgo.MessageEmbed{
 						{
-							URL:         "https://ccil-kbw.com/iqama",
 							Type:        discordgo.EmbedTypeRich,
-							Title:       "Iqama Time",
-							Description: "Iqama pulled from https://ccil-kbw.com/iqama",
-							Color:       0x05993e,
+							Title:       "Scheduling Start",
+							Description: "OBS Scheduling Start Operation",
+							Color:       0x05294e,
 							Fields: func() []*discordgo.MessageEmbedField {
+								msgs <- "obs-start"
+								now := time.Now()
 								return []*discordgo.MessageEmbedField{
 									{
-										Name:  "Test",
-										Value: "Test",
+										Name:  "OBS Recording Started",
+										Value: fmt.Sprintf("Will be scheduling until %d:%d", now.Hour(), now.Minute()),
 									},
 								}
 							}(),
@@ -62,7 +65,7 @@ var (
 )
 
 // Run the Discord bot. NOTE: Function can be split
-func Run(guildID, botToken *string, removeCommands *bool) {
+func Run(guildID, botToken *string, removeCommands *bool, msgs chan string) {
 	var err error
 	var s *discordgo.Session
 
@@ -73,13 +76,14 @@ func Run(guildID, botToken *string, removeCommands *bool) {
 
 	s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		if h, ok := commandHandlers[i.ApplicationCommandData().Name]; ok {
-			h(s, i)
+			h(s, i, msgs)
 		}
 	})
 
 	s.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
 		log.Printf("Logged in as: %v#%v", s.State.User.Username, s.State.User.Discriminator)
 	})
+
 	err = s.Open()
 	if err != nil {
 		log.Fatalf("Cannot open the session: %v", err)
@@ -99,7 +103,7 @@ func Run(guildID, botToken *string, removeCommands *bool) {
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt)
-	log.Println("Press Ctrl+C to exit")
+	fmt.Println("Press Ctrl+C to exit")
 	<-stop
 
 	if *removeCommands {

--- a/mappers/iqamadiscord.go
+++ b/mappers/iqamadiscord.go
@@ -1,11 +1,14 @@
 package mappers
 
 import (
+	"fmt"
+
 	"github.com/bwmarrin/discordgo"
 	iqamav1 "github.com/ccil-kbw/robot/iqama/v1"
 )
 
 func IqamaTimesToDiscordInteractionResponseData(resp iqamav1.Resp) *discordgo.InteractionResponseData {
+	fmt.Println("discord command called: /iqama")
 	return &discordgo.InteractionResponseData{
 		Embeds: []*discordgo.MessageEmbed{
 			{

--- a/rec/rec.go
+++ b/rec/rec.go
@@ -10,9 +10,13 @@ type Recorder struct {
 	client *goobs.Client
 }
 
-func New(password string) (*Recorder, error) {
+func New(host, password string) (*Recorder, error) {
 
-	client, err := goobs.New("localhost:4455", goobs.WithPassword(password))
+	if host == "" {
+		host = "localhost:4455"
+	}
+
+	client, err := goobs.New(host, goobs.WithPassword(password))
 	if err != nil {
 		return nil, err
 	}
@@ -30,6 +34,11 @@ func New(password string) (*Recorder, error) {
 	return &Recorder{
 		client: client,
 	}, nil
+}
+
+func (o *Recorder) DispatchOperation(msg string) error {
+	fmt.Printf("[todo] dispatching operation: %s\n", msg)
+	return nil
 }
 
 func (o *Recorder) Disconnect() error {


### PR DESCRIPTION
Added a communication channel between discord and obs module in the monolith binary

This PR will be ready to merge when:
- `/obs-record` discord bot command will start recording for a default 2hours duration
- `/obs-record-add-time` will either take an int parameter (in hours) or just name it `/obs-record-add-1-hour` will just extend the current recording by 1 hour
- `/obs-status` will return information about the status of OBS (reachability, recording, current recording time, today's schedule)