### PR TITLE
feat: read iqama and adhan times from the CSV

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
-	iqamav1 "github.com/ccil-kbw/robot/iqama/v1"
+	"fmt"
+	iqamav2 "github.com/ccil-kbw/robot/iqama/v2"
 )
 
 func main() {
-	_ = iqamav1.GetShellPrettified()
+	client := iqamav2.NewIqamaCSV("iqama_2024.csv")
+
+	fmt.Println(client.GetShellPrettified())
 }

--- a/iqama/v2/const.go
+++ b/iqama/v2/const.go
@@ -1,0 +1,6 @@
+package v2
+
+const (
+	DateFormat = "01/02/2006"
+	TimeFormat = "3:04 pm"
+)

--- a/iqama/v2/csv_helpers.go
+++ b/iqama/v2/csv_helpers.go
@@ -1,0 +1,14 @@
+package v2
+
+import (
+	"errors"
+	"time"
+)
+
+func (i *IqamaCSV) iqamaForDate(date time.Time) (IqamaDailyTimes, error) {
+	times, ok := i.iqamaTimes[date.Format("01/02/2006")]
+	if !ok {
+		return IqamaDailyTimes{}, errors.New("could not get iqama times for date")
+	}
+	return times, nil
+}

--- a/iqama/v2/csv_test.go
+++ b/iqama/v2/csv_test.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"reflect"
 	"testing"
 	"time"
 )
@@ -30,89 +29,51 @@ func TestNewIqamaCSV(t *testing.T) {
 }
 
 func TestIqamaCSV_GetTodayTimes(t *testing.T) {
-	type fields struct {
-		filePath   string
-		iqamaTimes map[time.Time]IqamaDailyTimes
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		want    *IqamaDailyTimes
-		wantErr bool
-	}{
-		{
-			name: "TestIqamaCSV_GetTodayTimes",
-			fields: fields{
-				filePath:   "test_assets/iqama_2024.csv",
-				iqamaTimes: nil,
-			},
-			want:    nil,
-			wantErr: false,
-		},
+	// Manually Load CSV and read Today's Record
+	i := NewIqamaCSV("test_assets/iqama_2024.csv")
+	daily, err := i.GetTodayTimes()
+	if err != nil {
+		t.Errorf("IqamaCSV.GetTodayTimes() error = %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			i := &IqamaCSV{
-				filePath:   tt.fields.filePath,
-				iqamaTimes: tt.fields.iqamaTimes,
-			}
-			got, err := i.GetTodayTimes()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("IqamaCSV.GetTodayTimes() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("IqamaCSV.GetTodayTimes() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestIqamaCSV_GetTomorrowTimes(t *testing.T) {
-	type fields struct {
-		filePath   string
-		iqamaTimes map[time.Time]IqamaDailyTimes
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		want    *IqamaDailyTimes
-		wantErr bool
-	}{
-		{
-			name: "TestIqamaCSV_GetTomorrowTimes",
-			fields: fields{
-				filePath:   "test_assets/iqama_2024.csv",
-				iqamaTimes: nil,
-			},
-			want:    nil,
-			wantErr: false,
-		},
+	if daily.Date.Format(DateFormat) != time.Now().Format(DateFormat) {
+		t.Errorf("IqamaCSV.GetTodayTimes() = %v, want %v", daily.Date, time.Now().Format("01/02/2006"))
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			i := &IqamaCSV{
-				filePath:   tt.fields.filePath,
-				iqamaTimes: tt.fields.iqamaTimes,
-			}
-			got, err := i.GetTomorrowTimes()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("IqamaCSV.GetTomorrowTimes() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("IqamaCSV.GetTomorrowTimes() = %v, want %v", got, tt.want)
-			}
-		})
+	// For the following tests we will only look at the hours of the time.Time objects
+	// This will allow us to compare the times without worrying about the date
+
+	// Assert that Fajr is after 3:00 am (Summer) and before 7am (Winter)
+	if daily.Fajr.Adhan.Hour() < 3 || daily.Fajr.Adhan.Hour() > 6 {
+		t.Errorf("IqamaCSV.GetTodayTimes() = %v, want between 3am and 6am", daily.Fajr.Adhan)
+	}
+
+	// Assert that Dhuhr is after 11:00 am and before 2pm
+	if daily.Dhuhr.Adhan.Hour() < 11 || daily.Dhuhr.Adhan.Hour() > 14 {
+		t.Errorf("IqamaCSV.GetTodayTimes() = %v, want between 12pm and 1pm", daily.Dhuhr.Adhan)
+	}
+
+	// Assert that Asr is after 2:00 pm and before 5pm
+	if daily.Asr.Adhan.Hour() < 14 || daily.Asr.Adhan.Hour() > 17 {
+		t.Errorf("IqamaCSV.GetTodayTimes() = %v, want between 2pm and 5pm", daily.Asr.Adhan)
+	}
+
+	// Assert that Maghrib is after 4:00 pm and before 9pm
+	if daily.Maghrib.Adhan.Hour() < 16 || daily.Maghrib.Adhan.Hour() > 21 {
+		t.Errorf("IqamaCSV.GetTodayTimes() = %v, want between 5pm and 8pm", daily.Maghrib.Adhan)
+	}
+
+	// Assert that Isha is after 5:00 pm and before 11pm
+	if daily.Isha.Adhan.Hour() < 17 || daily.Isha.Adhan.Hour() > 23 {
+		t.Errorf("IqamaCSV.GetTodayTimes() = %v, want between 6pm and 9pm", daily.Isha.Adhan)
+
 	}
 }
 
 func TestIqamaCSV_GetDiscordPrettified(t *testing.T) {
 	type fields struct {
 		filePath   string
-		iqamaTimes map[time.Time]IqamaDailyTimes
+		iqamaTimes map[string]IqamaDailyTimes
 	}
 	tests := []struct {
 		name   string

--- a/iqama/v2/helpers.go
+++ b/iqama/v2/helpers.go
@@ -6,14 +6,40 @@ import (
 	"time"
 )
 
-func toTable(m map[time.Time]IqamaDailyTimes) table.Writer {
+func toTable(m map[string]IqamaDailyTimes) table.Writer {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.AppendHeader(table.Row{"Date", "Fajr", "Dhuhur", "Asr", "Maghrib", "Isha"})
 	for date, times := range m {
 		t.AppendRows([]table.Row{
-			{date.Format("2006-01-02"), times.Fajr, times.Dhuhr, times.Asr, times.Maghrib, times.Isha},
+			{date, times.Fajr, times.Dhuhr, times.Asr, times.Maghrib, times.Isha},
 		})
 	}
 	return t
+}
+
+func toTableDaily(m IqamaDailyTimes) table.Writer {
+	t := table.NewWriter()
+	t.AppendHeader(table.Row{"Date", "Fajr", "Dhuhur", "Asr", "Maghrib", "Isha"})
+	t.AppendRows([]table.Row{
+		{FormatDate(m.Date), FormatTime(m.Fajr.Iqama), FormatTime(m.Dhuhr.Iqama), FormatTime(m.Asr.Iqama), FormatTime(m.Maghrib.Iqama), FormatTime(m.Isha.Iqama)}})
+	return t
+}
+
+// ParseHoursMinutes parses a string in the format "15:04" and returns a time.Time
+func ParseHoursMinutes(s string) (time.Time, error) {
+	return time.Parse("3:04 pm", s)
+}
+
+// ParseDate parses a string in the format "01/02/2006" (Month/Day/Year) and returns a time.Time
+func ParseDate(s string) (time.Time, error) {
+	return time.Parse("01/02/2006", s)
+}
+
+func FormatDate(t time.Time) string {
+	return t.Format("01/02/2006")
+}
+
+func FormatTime(t time.Time) string {
+	return t.Format("3:04 pm")
 }


### PR DESCRIPTION
In this Pull Request I'm adding the capability to read Today's time directly from the CSV to remove external dependencies.

To test:

```sh
go test -v -cover ./...
```

To run the code:

```sh
go run ./cmd/cli/main.go
```

You should directly see this output:

```sh
robot on  feat/shell-prettier
❯ go run ./cmd/cli/main.go
+------------+---------+---------+---------+---------+---------+
| DATE       | FAJR    | DHUHUR  | ASR     | MAGHRIB | ISHA    |
+------------+---------+---------+---------+---------+---------+
| 04/11/2024 | 5:15 am | 1:15 pm | 6:15 pm | 7:38 pm | 9:02 pm |
+------------+---------+---------+---------+---------+---------+
```

That CLI (`./cmd/cli/main.go`) is calling the GetShellPettrified which in return calls GetTodayTime from the v2/csv package